### PR TITLE
Issue 33 unify with frontend

### DIFF
--- a/api/openapi-spec/openapi.yaml
+++ b/api/openapi-spec/openapi.yaml
@@ -121,6 +121,12 @@ paths:
             type: integer
             example: 4
             default: -1
+        - name: show
+          in: query
+          description: set to 'public' (the only possible value other than omitting this parameter) to list only groups available for joining. Mandatory for ordinary non-admin users. May be set for admins to essentially treat them like a normal user looking for a public group to join. Note that public groups may be disabled in the configuration, in which case this request will always return an empty list.
+          schema:
+            type: string
+            example: public
       responses:
         '200':
           description: successful operation

--- a/api/openapi-spec/openapi.yaml
+++ b/api/openapi-spec/openapi.yaml
@@ -372,6 +372,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
+        '502':
+          description: The attendee service failed to respond when asked for the user's registrations.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
       security:
         - BearerAuth: []
         - ApiKeyAuth: []
@@ -442,6 +448,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
+        '502':
+          description: The attendee service failed to respond when asked for the user's registrations.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
       security:
         - BearerAuth: []
         - ApiKeyAuth: []
@@ -493,6 +505,12 @@ paths:
                 $ref: '#/components/schemas/Error'
         '500':
           description: An unexpected error occurred. This includes database errors. A best effort attempt is made to return details in the body.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '502':
+          description: The attendee service failed to respond when asked for the user's registrations.
           content:
             application/json:
               schema:
@@ -630,6 +648,12 @@ paths:
                 $ref: '#/components/schemas/Error'
         '500':
           description: An unexpected error occurred. This includes database errors. A best effort attempt is made to return details in the body.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '502':
+          description: The attendee service failed to respond when asked for the user's registrations.
           content:
             application/json:
               schema:

--- a/internal/controller/v1/groupsctl/groups_get.go
+++ b/internal/controller/v1/groupsctl/groups_get.go
@@ -15,13 +15,14 @@ import (
 )
 
 type ListGroupsRequest struct {
-	MemberIDs []int64
-	MinSize   uint
-	MaxSize   int
+	MemberIDs  []int64
+	MinSize    uint
+	MaxSize    int
+	PublicOnly bool
 }
 
 func (h *Controller) ListGroups(ctx context.Context, req *ListGroupsRequest, w http.ResponseWriter) (*modelsv1.GroupList, error) {
-	groups, err := h.svc.FindGroups(ctx, req.MinSize, req.MaxSize, req.MemberIDs)
+	groups, err := h.svc.FindGroups(ctx, req.MinSize, req.MaxSize, req.MemberIDs, req.PublicOnly)
 	if err != nil {
 		return nil, err
 	}
@@ -65,6 +66,14 @@ func (h *Controller) ListGroupsRequest(r *http.Request, w http.ResponseWriter) (
 		req.MaxSize = val
 	} else {
 		req.MaxSize = -1
+	}
+
+	if show := query.Get("show"); show != "" {
+		if show == "public" {
+			req.PublicOnly = true
+		} else {
+			return nil, common.NewBadRequest(ctx, common.RequestParseFailed, common.Details("show parameter should be 'public' or missing"))
+		}
 	}
 
 	return &req, nil

--- a/internal/service/groups/interface.go
+++ b/internal/service/groups/interface.go
@@ -22,7 +22,7 @@ type Service interface {
 	// The same link will also be included in the email sent to the invited attendee.
 	AddMemberToGroup(ctx context.Context, req *AddGroupMemberParams) (string, error)
 	RemoveMemberFromGroup(ctx context.Context, req *RemoveGroupMemberParams) error
-	FindGroups(ctx context.Context, minSize uint, maxSize int, memberIDs []int64) ([]*modelsv1.Group, error)
+	FindGroups(ctx context.Context, minSize uint, maxSize int, memberIDs []int64, public bool) ([]*modelsv1.Group, error)
 	FindMyGroup(ctx context.Context) (*modelsv1.Group, error)
 }
 

--- a/internal/service/groups/members.go
+++ b/internal/service/groups/members.go
@@ -87,7 +87,7 @@ func (g *groupService) AddMemberToGroup(ctx context.Context, req *AddGroupMember
 				return "", errGroupWrite(ctx, err.Error())
 			}
 
-			informOwnerTemplate = "group-member-request"
+			informOwnerTemplate = "group-member-applied"
 		} else if grp.Owner == loggedInAttendee.ID {
 			// owner trying to invite another attendee - check nickname matches
 
@@ -235,7 +235,7 @@ func (g *groupService) RemoveMemberFromGroup(ctx context.Context, req *RemoveGro
 		adjustBan = true
 		if gm.IsInvite {
 			aulogging.Infof(ctx, "declined join request - group %s badge %d by owner %s", req.GroupID, req.BadgeNumber, common.GetSubject(ctx))
-			informMemberTemplate = "group-request-declined" // your request to join was declined
+			informMemberTemplate = "group-application-declined" // your request to join was declined
 		} else {
 			aulogging.Infof(ctx, "kick from group - group %s badge %d by owner %s", req.GroupID, req.BadgeNumber, common.GetSubject(ctx))
 			informMemberTemplate = "group-member-kicked"
@@ -243,7 +243,7 @@ func (g *groupService) RemoveMemberFromGroup(ctx context.Context, req *RemoveGro
 	} else if gm.ID == loggedInAttendee.ID {
 		if gm.IsInvite {
 			aulogging.Infof(ctx, "declined group invitation - group %s badge %d by self", req.GroupID, req.BadgeNumber)
-			informOwnerTemplate = "group-request-declined" // your request to join was declined
+			informOwnerTemplate = "group-invitation-declined" // your request to join was declined
 		} else {
 			aulogging.Infof(ctx, "left group - group %s badge %d by self", req.GroupID, req.BadgeNumber)
 			informOwnerTemplate = "group-member-left" // member left
@@ -344,6 +344,7 @@ func (g *groupService) sendInfoMails(ctx context.Context, informOwnerTemplate st
 			Variables: map[string]string{
 				"nickname":  member.Nickname,
 				"groupname": grp.Name,
+				"owner":     owner.Nickname,
 			},
 		}
 		if inviteCode != "" {

--- a/test/acceptance/groups_member_add_test.go
+++ b/test/acceptance/groups_member_add_test.go
@@ -33,7 +33,7 @@ func TestGroupsAddMember_OwnerFirstSuccess(t *testing.T) {
 
 	docs.Then("And the expected mail has been sent to the invited attendee")
 	tstRequireMailRequests(t,
-		tstGroupMailToMember("group-invited", "kittens", "1234567890", response.location))
+		tstGroupMailToMember("group-invited", "kittens", "1234567890", "101", response.location))
 
 	docs.Then("And the personalized join link can be used by the invited attendee")
 	joinResponse := tstPerformPostNoBody(response.location, tstValidUserToken(t, 1234567890))
@@ -65,7 +65,7 @@ func TestGroupsAddMember_AttendeeFirstSuccess(t *testing.T) {
 
 	docs.Then("And the expected mail is sent to the owner to inform them about the application")
 	tstRequireMailRequests(t,
-		tstGroupMailToOwner("group-member-request", "kittens", "101", "1234567890"))
+		tstGroupMailToOwner("group-member-applied", "kittens", "101", "1234567890"))
 
 	docs.Then("And the owner can accept the application")
 	acceptResponse := tstPerformPostNoBody(response.location, tstValidUserToken(t, 101))
@@ -73,7 +73,7 @@ func TestGroupsAddMember_AttendeeFirstSuccess(t *testing.T) {
 
 	docs.Then("And the expected mail is then sent to the invited attendee")
 	tstRequireMailRequests(t,
-		tstGroupMailToMember("group-application-accepted", "kittens", "1234567890", ""))
+		tstGroupMailToMember("group-application-accepted", "kittens", "1234567890", "101", ""))
 }
 
 func TestGroupsAddMember_AdminForceSuccess(t *testing.T) {

--- a/test/acceptance/groups_member_remove_test.go
+++ b/test/acceptance/groups_member_remove_test.go
@@ -31,7 +31,7 @@ func TestGroupsRemoveMember_OwnerSuccess(t *testing.T) {
 
 	docs.Then("And the expected mail has been sent to the removed attendee")
 	tstRequireMailRequests(t,
-		tstGroupMailToMember("group-member-kicked", "kittens", "202", ""))
+		tstGroupMailToMember("group-member-kicked", "kittens", "202", "101", ""))
 }
 
 func TestGroupsRemoveMember_AttendeeSelfSuccess(t *testing.T) {
@@ -78,7 +78,7 @@ func TestGroupsRemoveMember_AdminSuccess(t *testing.T) {
 	docs.Then("And the expected emails have been sent")
 	tstRequireMailRequests(t,
 		tstGroupMailToOwner("group-member-removed", "kittens", "101", "202"),
-		tstGroupMailToMember("group-member-kicked", "kittens", "202", ""),
+		tstGroupMailToMember("group-member-kicked", "kittens", "202", "101", ""),
 	)
 }
 
@@ -104,7 +104,7 @@ func TestGroupsRemoveMember_AttendeeSelfInviteDeclineSuccess(t *testing.T) {
 
 	docs.Then("And the expected mail is sent to the owner to inform them")
 	tstRequireMailRequests(t,
-		tstGroupMailToOwner("group-request-declined", "kittens", "101", "202"))
+		tstGroupMailToOwner("group-invitation-declined", "kittens", "101", "202"))
 }
 
 func TestGroupsRemoveMember_ThirdPartyDeny(t *testing.T) {

--- a/test/acceptance/groups_update_test.go
+++ b/test/acceptance/groups_update_test.go
@@ -178,3 +178,5 @@ func TestGroupsUpdate_NotFound(t *testing.T) {
 }
 
 // TODO change leads to duplicate group name
+
+// TODO owner change (incl. email check)

--- a/test/acceptance/testcase_attendees_test.go
+++ b/test/acceptance/testcase_attendees_test.go
@@ -223,8 +223,9 @@ func tstGroupMailToOwner(cid string, groupName string, target string, object str
 	}
 }
 
-func tstGroupMailToMember(cid string, groupName string, target string, url string) mailservice.MailSendDto {
+func tstGroupMailToMember(cid string, groupName string, target string, owner string, url string) mailservice.MailSendDto {
 	_, targetNick, targetEmail := tstInfosBySubject(target)
+	_, ownerNick, _ := tstInfosBySubject(owner)
 
 	result := mailservice.MailSendDto{
 		CommonID: cid,
@@ -233,6 +234,7 @@ func tstGroupMailToMember(cid string, groupName string, target string, url strin
 		Variables: map[string]string{
 			"nickname":  targetNick,
 			"groupname": groupName,
+			"owner":     ownerNick,
 		},
 	}
 	if url != "" {


### PR DESCRIPTION
- closes #33 

This finalizes the first round of implementing this service, now unified with the expectations of the two frontends.

Next step is to test it all and fix any issues that arise.